### PR TITLE
Create requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+tweepy
+tqdm
+peewee
+facebook-sdk
+python-instagram
+datetime
+requests
+urllib3
+httplib2
+bs4


### PR DESCRIPTION
Instead of forcing new users to install the dependencies by running all the commands in the README, a `requirements.txt` will allow users to simply run `pip install -r requirements.txt`, as per [this](https://pip.readthedocs.io/en/1.1/requirements.html) PIP spec.